### PR TITLE
Fix redis install in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,4 @@ stevedore>=1.20.0 # Apache-2.0
 tooz>=1.58.0 # Apache-2.0
 WebOb>=1.7.1 # MIT
 pysnmp>=4.4.11 # BSD
-redis=3.3.8
+redis>=3.3.8


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes the syntax in requirements.txt for redis install
Either == or >= to be used instead of =

Currently it throws below error
![image](https://user-images.githubusercontent.com/30930862/80187754-d1d0e500-862d-11ea-855a-b783e0724c5d.png)



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
After fix:
![image](https://user-images.githubusercontent.com/30930862/80188058-460b8880-862e-11ea-8e8d-539a551e8f8f.png)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
