### PR TITLE
Update storages/<id>/access-info API Implementaion

### DIFF
--- a/dolphin/api/schemas/access_info.py
+++ b/dolphin/api/schemas/access_info.py
@@ -1,0 +1,35 @@
+# Copyright 2020 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dolphin.api.validation import parameter_types
+
+update = {
+    'type': 'object',
+    'properties': {
+        'host': parameter_types.hostname_or_ip_address,
+        'port': parameter_types.tcp_udp_port,
+        'username': {'type': 'string', 'minLength': 1, 'maxLength': 255},
+        'password': {'type': 'string', 'minLength': 1, 'maxLength': 255},
+        'extra_attributes': {
+            'type': 'object',
+            'patternProperties': {
+                '^[a-zA-Z0-9-_:. ]{1,255}$': {
+                    'type': 'string', 'maxLength': 255
+                }
+            }
+        }
+    },
+    'required': ['username', 'password'],
+    'additionalProperties': False
+}

--- a/dolphin/api/v1/access_info.py
+++ b/dolphin/api/v1/access_info.py
@@ -70,7 +70,7 @@ class AccessInfoController(wsgi.Controller):
             msg = _('Failed to to update  access info: {0}'.format(e))
             LOG.error(msg)
             raise exc.HTTPBadRequest(explanation=msg)
-        return storage_view.build_storage(storage)
+        return self._view_builder.show(access_info)
 
 
 def create_resource():

--- a/dolphin/api/v1/access_info.py
+++ b/dolphin/api/v1/access_info.py
@@ -11,13 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from dolphin.api import validation
 from webob import exc
 
-from dolphin import db
+from dolphin import db, cryptor
 from dolphin import exception
-from dolphin.api.common import wsgi
+from dolphin.api.common import wsgi, LOG
 from dolphin.api.views import access_info as access_info_viewer
+from dolphin.drivers import api as driverapi
+from dolphin.api.views import storages as storage_view
+from dolphin.i18n import _
+from dolphin.api.schemas import access_info as schema_access_info
 
 
 class AccessInfoController(wsgi.Controller):
@@ -25,6 +29,7 @@ class AccessInfoController(wsgi.Controller):
     def __init__(self):
         super(AccessInfoController, self).__init__()
         self._view_builder = access_info_viewer.ViewBuilder()
+        self.driver_api = driverapi.API()
 
     def show(self, req, id):
         """Show access information by storage id."""
@@ -37,8 +42,38 @@ class AccessInfoController(wsgi.Controller):
 
         return self._view_builder.show(access_info)
 
+    @validation.schema(schema_access_info.update)
+    def update(self, req, id, body):
+        """Update storage access information."""
+        ctxt = req.environ.get('dolphin.context')
+        # Get existing access_info and storage from DB
+        try:
+            access_info_present = db.access_info_get(ctxt, id)
+            storage_present = db.storage_get(ctxt, id)
+            access_info_updated_dict = access_info_present.to_dict()
+            access_info_updated_dict.update(body)
+            # Discover storage with new access info
+            storage = self.driver_api.discover_storage(ctxt, access_info_updated_dict)
+            if storage['serial_number'] != storage_present.serial_number:
+                reason = (_("Existing storage serial Number is not matching with th new storage serial number: '%s'  "
+                            ) %
+                          storage['serial_number'])
+                raise exception.StorageSerialNumberMismatch(reason=reason)
+            db.storage_update(ctxt, id, storage)
+            access_info_updated_dict['password'] = cryptor.encode(access_info_updated_dict['password'])
+            db.access_info_update(ctxt, id, access_info_updated_dict)
+        except (exception.InvalidCredential,
+                exception.StorageDriverNotFound,
+                exception.AccessInfoNotFound,
+                exception.StorageNotFound,
+                exception.StorageSerialNumberMismatch) as e:
+            raise exc.HTTPBadRequest(explanation=e.message)
+        except Exception as e:
+            msg = _('Failed to to update  access info: {0}'.format(e))
+            LOG.error(msg)
+            raise exc.HTTPBadRequest(explanation=msg)
+        return storage_view.build_storage(storage)
+
 
 def create_resource():
     return wsgi.Resource(AccessInfoController())
-
-

--- a/dolphin/api/v1/access_info.py
+++ b/dolphin/api/v1/access_info.py
@@ -55,12 +55,12 @@ class AccessInfoController(wsgi.Controller):
             # Discover storage with new access info
             storage = self.driver_api.discover_storage(ctxt, access_info_updated_dict)
             if storage['serial_number'] != storage_present.serial_number:
-                reason = (_("Existing storage serial Number is not matching with th new storage serial number: '%s'  "
-                            ) %
-                          storage['serial_number'])
+                reason = (_("Existing storage serial Number is not matching \
+                with th new storage serial number: '%s'  ") % storage['serial_number'])
                 raise exception.StorageSerialNumberMismatch(reason=reason)
             db.storage_update(ctxt, id, storage)
-            access_info_updated_dict['password'] = cryptor.encode(access_info_updated_dict['password'])
+            access_info_updated_dict['password'] = cryptor.encode(
+                access_info_updated_dict['password'])
             db.access_info_update(ctxt, id, access_info_updated_dict)
         except (exception.InvalidCredential,
                 exception.StorageDriverNotFound,

--- a/dolphin/api/v1/router.py
+++ b/dolphin/api/v1/router.py
@@ -45,6 +45,10 @@ class APIRouter(common.APIRouter):
                        action="show",
                        conditions={"method": ["GET"]})
 
+        mapper.connect("storages", "/storages/{id}/access-info",
+                       controller=self.resources['access_info'],
+                       action="update",
+                       conditions={"method": ["PUT"]})
         self.resources['pools'] = pools.create_resource()
         mapper.resource("pool", "pools",
                         controller=self.resources['pools'])

--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -110,7 +110,7 @@ class StorageController(wsgi.Controller):
             raise exc.HTTPBadRequest(explanation=msg)
 
         try:
-            storage = self.driver_api.register_storage(ctxt, access_info_dict)
+            storage = self.driver_api.discover_storage(ctxt, access_info_dict)
             storage = db.storage_create(context, storage)
 
             # Need to encode the password before saving.

--- a/dolphin/db/sqlalchemy/api.py
+++ b/dolphin/db/sqlalchemy/api.py
@@ -173,7 +173,12 @@ def access_info_create(context, values):
 
 def access_info_update(context, access_info_id, values):
     """Update a storage access information with the values dictionary."""
-    return NotImplemented
+    session = get_session()
+    with session.begin():
+        result = session.query(AccessInfo) \
+            .filter(AccessInfo.storage_id == access_info_id) \
+            .first().update(values)
+    return result
 
 
 def access_info_get(context, storage_id):

--- a/dolphin/db/sqlalchemy/api.py
+++ b/dolphin/db/sqlalchemy/api.py
@@ -246,11 +246,8 @@ def storage_update(context, storage_id, values):
     """Update a storage device with the values dictionary."""
     session = get_session()
     with session.begin():
-        query = _storage_get_query(context, session)
-        result = query.filter_by(id=storage_id).update(values)
-        if not result:
-            raise exception.StorageNotFound(id=storage_id)
-    return result
+        result = _access_info_get(context, storage_id, session).update(values)
+        return result
 
 
 def storage_get(context, storage_id):

--- a/dolphin/db/sqlalchemy/api.py
+++ b/dolphin/db/sqlalchemy/api.py
@@ -175,10 +175,8 @@ def access_info_update(context, access_info_id, values):
     """Update a storage access information with the values dictionary."""
     session = get_session()
     with session.begin():
-        result = session.query(AccessInfo) \
-            .filter(AccessInfo.storage_id == access_info_id) \
-            .first().update(values)
-    return result
+        result = _access_info_get(context, access_info_id, session).update(values)
+        return result
 
 
 def access_info_get(context, storage_id):

--- a/dolphin/drivers/api.py
+++ b/dolphin/drivers/api.py
@@ -31,12 +31,17 @@ class API(object):
         """Show register parameters which the driver needs."""
         pass
 
-    def register_storage(self, context, access_info):
-        """Discovery a storage system with access information."""
-        access_info['storage_id'] = six.text_type(uuidutils.generate_uuid())
-        driver = self.driver_manager.create_driver(context, **access_info)
+    def discover_storage(self, context, access_info):
+        """Discover a storage system with access information and create driver instance ."""
 
-        storage = driver.register_storage(context)
+        if 'storage_id' not in access_info:
+            access_info['storage_id'] = six.text_type(uuidutils.generate_uuid())
+        else:
+            # Already registered storage , remove driver and create driver instance again with new access_info
+            self.driver_manager.remove_driver(context,access_info['storage_id'])
+
+        driver = self.driver_manager.create_driver(context, **access_info)
+        storage = driver.get_storage(context)
         if storage:
             storage['id'] = access_info['storage_id']
         else:

--- a/dolphin/drivers/api.py
+++ b/dolphin/drivers/api.py
@@ -37,7 +37,8 @@ class API(object):
         if 'storage_id' not in access_info:
             access_info['storage_id'] = six.text_type(uuidutils.generate_uuid())
         else:
-            # Already registered storage , remove driver and create driver instance again with new access_info
+            # Already registered storage , remove driver and create driver instance \
+            # again with new access_info
             self.driver_manager.remove_driver(context,access_info['storage_id'])
 
         driver = self.driver_manager.create_driver(context, **access_info)

--- a/dolphin/drivers/fake_storage/__init__.py
+++ b/dolphin/drivers/fake_storage/__init__.py
@@ -44,7 +44,20 @@ class FakeStorageDriver(driver.StorageDriver):
         }
 
     def get_storage(self, context):
-        pass
+        # Do something here
+        return {
+            'name': 'fake_driver',
+            'description': 'it is a fake driver.',
+            'vendor': 'fake_storage',
+            'model': 'fake_driver',
+            'status': 'normal',
+            'serial_number': '2102453JPN12KA000011',
+            'firmware_version': '1.0.0',
+            'location': 'HK',
+            'total_capacity': 1024 * 1024,
+            'used_capacity': 3126,
+            'free_capacity': 1045449,
+        }
 
     def list_pools(self, context):
         pass

--- a/dolphin/exception.py
+++ b/dolphin/exception.py
@@ -255,6 +255,11 @@ class StorageDriverNotFound(NotFound):
     message = _("Storage driver could not be found.")
 
 
+class StorageSerialNumberMismatch(DolphinException):
+    message = _("Storage  serial number  mismatch: "
+                "%(reason)s")
+
+
 class ServiceIsDown(Invalid):
     message = _("Service %(service)s is down.")
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update registerd storage information.
API will
- validate schema
- merge  new storage access parameter with old ( if thee are some fields provided, will take those fields from already registerd access_info)
- mandate password and username as required parameters
- contact driver manager to get storage with new access_info
- update access info and staorage info on successfull get_storage() 
**Which issue this PR fixes** 
NA

**Special notes for your reviewer**:
has dependency with PR #30 for displaying discoverd storage info

**Test Report**:

Register storage first
![image](https://user-images.githubusercontent.com/45681499/81302440-00bc7180-9098-11ea-95c9-a4f005b5346a.png)

update Access info with wrong parametrs  [Negetive usecase]
![image](https://user-images.githubusercontent.com/45681499/81302844-83453100-9098-11ea-9602-aeb73a97d83c.png)

update storage info [postive case]
![image](https://user-images.githubusercontent.com/45681499/81302922-a40d8680-9098-11ea-9406-a922fd9571c1.png)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
