### PR TITLE
Fix issue when registering storage

### DIFF
--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -96,7 +96,7 @@ class StorageController(wsgi.Controller):
         access_info_dict = body
 
         if self._storage_exist(ctxt, access_info_dict):
-            msg = _("Storage has been registered.")
+            msg = _("Storage already exists.")
             raise exc.HTTPBadRequest(explanation=msg)
 
         try:

--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -20,7 +20,6 @@ from webob import exc
 
 from dolphin import context
 from dolphin import coordination
-from dolphin import cryptor
 from dolphin import db
 from dolphin import exception
 from dolphin.api import api_utils
@@ -96,27 +95,19 @@ class StorageController(wsgi.Controller):
         ctxt = req.environ['dolphin.context']
         access_info_dict = body
 
-        if self._is_registered(ctxt, access_info_dict):
+        if self._storage_exist(ctxt, access_info_dict):
             msg = _("Storage has been registered.")
             raise exc.HTTPBadRequest(explanation=msg)
 
         try:
-            storage = self.driver_api.discover_storage(ctxt, access_info_dict)
-            storage = db.storage_create(context, storage)
-
-            # Need to encode the password before saving.
-            access_info_dict['storage_id'] = storage['id']
-            access_info_dict['password'] = cryptor.encode(access_info_dict['password'])
-            db.access_info_create(context, access_info_dict)
+            storage = self.driver_api.discover_storage(ctxt,
+                                                       access_info_dict)
         except (exception.InvalidCredential,
+                exception.InvalidRequest,
+                exception.InvalidResults,
                 exception.StorageDriverNotFound,
-                exception.AccessInfoNotFound,
                 exception.StorageNotFound) as e:
-            raise exc.HTTPBadRequest(explanation=e.message)
-        except Exception as e:
-            msg = _('Failed to register storage: {0}'.format(e))
-            LOG.error(msg)
-            raise exc.HTTPBadRequest(explanation=msg)
+            raise exc.HTTPBadRequest(explanation=e.msg)
 
         return storage_view.build_storage(storage)
 
@@ -184,19 +175,30 @@ class StorageController(wsgi.Controller):
 
         return
 
-    def _is_registered(self, context, access_info):
+    def _storage_exist(self, context, access_info):
         access_info_dict = copy.deepcopy(access_info)
 
         # Remove unrelated query fields
-        access_info_dict.pop('username', None)
-        access_info_dict.pop('password', None)
-        access_info_dict.pop('vendor', None)
-        access_info_dict.pop('model', None)
+        unrelated_fields = ['username', 'password']
+        for key in unrelated_fields:
+            access_info_dict.pop(key)
 
         # Check if storage is registered
-        if db.access_info_get_all(context,
-                                  filters=access_info_dict):
-            return True
+        access_info_list = db.access_info_get_all(context,
+                                                  filters=access_info_dict)
+        for _access_info in access_info_list:
+            try:
+                storage = db.storage_get(context, _access_info['storage_id'])
+                if storage:
+                    return True
+            except exception.StorageNotFound:
+                # Suppose storage was not saved successfully after access
+                # information was saved in database when registering storage.
+                # Therefore, removing access info if storage doesn't exist to
+                # ensure the database has no residual data.
+                LOG.debug("Remove residual access information.")
+                db.access_info_delete(context, _access_info['storage_id'])
+
         return False
 
 

--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -105,6 +105,7 @@ class StorageController(wsgi.Controller):
         except (exception.InvalidCredential,
                 exception.InvalidRequest,
                 exception.InvalidResults,
+                exception.AccessInfoNotFound,
                 exception.StorageDriverNotFound,
                 exception.StorageNotFound) as e:
             raise exc.HTTPBadRequest(explanation=e.msg)

--- a/dolphin/db/api.py
+++ b/dolphin/db/api.py
@@ -269,6 +269,11 @@ def access_info_get(context, storage_id):
     return IMPL.access_info_get(context, storage_id)
 
 
+def access_info_delete(context, storage_id):
+    """Delete a storage access information."""
+    return IMPL.access_info_delete(context, storage_id)
+
+
 def access_info_get_all(context, marker=None, limit=None, sort_keys=None,
                         sort_dirs=None, filters=None, offset=None):
     """Retrieves all storage access information.

--- a/dolphin/db/api.py
+++ b/dolphin/db/api.py
@@ -259,9 +259,9 @@ def access_info_create(context, values):
     return IMPL.access_info_create(context, values)
 
 
-def access_info_update(context, access_info_id, values):
+def access_info_update(context, storage_id, values):
     """Update a storage access information with the values dictionary."""
-    return IMPL.access_info_update(context, access_info_id, values)
+    return IMPL.access_info_update(context, storage_id, values)
 
 
 def access_info_get(context, storage_id):
@@ -297,11 +297,6 @@ def access_info_get_all(context, marker=None, limit=None, sort_keys=None,
     """
     return IMPL.access_info_get_all(context, marker, limit, sort_keys, sort_dirs,
                                     filters, offset)
-
-
-def access_info_delete(context, storage_id):
-    """Delete a storage access information."""
-    return IMPL.access_info_delete(context, storage_id)
 
 
 def is_orm_value(obj):

--- a/dolphin/db/sqlalchemy/api.py
+++ b/dolphin/db/sqlalchemy/api.py
@@ -175,8 +175,14 @@ def access_info_update(context, access_info_id, values):
     """Update a storage access information with the values dictionary."""
     session = get_session()
     with session.begin():
-        result = _access_info_get(context, access_info_id, session).update(values)
-        return result
+        _access_info_get(context, access_info_id, session).update(values)
+        return _access_info_get(context, access_info_id, session)
+
+
+def access_info_delete(context, storage_id):
+    """Delete a storage access information."""
+    _access_info_get_query(context).\
+        filter_by(storage_id=storage_id).delete()
 
 
 def access_info_get(context, storage_id):

--- a/dolphin/db/sqlalchemy/api.py
+++ b/dolphin/db/sqlalchemy/api.py
@@ -171,12 +171,12 @@ def access_info_create(context, values):
                             session=session)
 
 
-def access_info_update(context, access_info_id, values):
+def access_info_update(context, storage_id, values):
     """Update a storage access information with the values dictionary."""
     session = get_session()
     with session.begin():
-        _access_info_get(context, access_info_id, session).update(values)
-        return _access_info_get(context, access_info_id, session)
+        _access_info_get(context, storage_id, session).update(values)
+        return _access_info_get(context, storage_id, session)
 
 
 def access_info_delete(context, storage_id):
@@ -217,11 +217,6 @@ def access_info_get_all(context, marker=None, limit=None, sort_keys=None,
         if query is None:
             return []
         return query.all()
-
-
-def access_info_delete(context, storage_id):
-    """Delete a storage access information."""
-    _access_info_get_query(context).filter_by(storage_id=storage_id).delete()
 
 
 @apply_like_filters(model=models.AccessInfo)

--- a/dolphin/db/sqlalchemy/models.py
+++ b/dolphin/db/sqlalchemy/models.py
@@ -48,6 +48,8 @@ class AccessInfo(BASE, DolphinBase):
     """Represent access info required for storage accessing."""
     __tablename__ = "access_info"
     storage_id = Column(String(36), primary_key=True)
+    vendor = Column(String(255))
+    model = Column(String(255))
     host = Column(String(255))
     port = Column(String(255))
     username = Column(String(255))

--- a/dolphin/drivers/api.py
+++ b/dolphin/drivers/api.py
@@ -38,8 +38,7 @@ class API(object):
         storage = driver.get_storage(context)
 
         # Need to validate storage response from driver
-        helper.check_storage_exist(context, storage)
-
+        helper.check_storage_repetition(context, storage)
         access_info = helper.create_access_info(context, access_info)
         storage['id'] = access_info['storage_id']
         storage = helper.create_storage(context, storage)
@@ -57,10 +56,7 @@ class API(object):
 
         # Need to validate storage response from driver
         storage_id = access_info['storage_id']
-        helper.check_storage_with_access_info(context,
-                                              storage_id,
-                                              storage_new)
-
+        helper.check_storage_consistency(context, storage_id, storage_new)
         access_info = helper.update_access_info(context, storage_id, access_info)
         helper.update_storage(context, storage_id, storage_new)
         self.driver_manager.update_driver(storage_id, driver)

--- a/dolphin/drivers/driver.py
+++ b/dolphin/drivers/driver.py
@@ -28,11 +28,6 @@ class StorageDriver(object):
         """
         self.storage_id = kwargs.get('storage_id', None)
 
-    @staticmethod
-    def get_storage_registry():
-        """Show register parameters which the driver needs."""
-        pass
-
     @abc.abstractmethod
     def get_storage(self, context):
         """Get storage device information from storage system"""

--- a/dolphin/drivers/fake_storage/__init__.py
+++ b/dolphin/drivers/fake_storage/__init__.py
@@ -23,10 +23,6 @@ class FakeStorageDriver(driver.StorageDriver):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    @staticmethod
-    def get_storage_registry():
-        pass
-
     def get_storage(self, context):
         # Do something here
         return {

--- a/dolphin/drivers/helper.py
+++ b/dolphin/drivers/helper.py
@@ -16,6 +16,8 @@ from oslo_log import log
 
 from dolphin import cryptor
 from dolphin import db
+from dolphin import exception
+from dolphin.i18n import _
 
 LOG = log.getLogger(__name__)
 
@@ -25,3 +27,57 @@ def get_access_info(context, storage_id):
     access_info_dict = access_info.to_dict()
     access_info_dict['password'] = cryptor.decode(access_info_dict['password'])
     return access_info_dict
+
+
+def create_access_info(context, access_info):
+    access_info['password'] = cryptor.encode(access_info['password'])
+    return db.access_info_create(context, access_info)
+
+
+def update_access_info(context, storage_id, access_info):
+    return db.access_info_update(context,
+                                 storage_id,
+                                 access_info)
+
+
+def create_storage(context, storage):
+    return db.storage_create(context, storage)
+
+
+def update_storage(context, storage_id, storage):
+    return db.storage_update(context, storage_id, storage)
+
+
+def check_storage_exist(context, storage):
+    if not storage:
+        msg = _("Storage could not be found.")
+        raise exception.StorageNotFound(message=msg)
+
+    if not storage.get('serial_number'):
+        msg = _("Serial number should be provided by storage.")
+        raise exception.InvalidResults(message=msg)
+
+    filters = dict(serial_number=storage['serial_number'])
+    storage_list = db.storage_get_all(context, filters=filters)
+    if storage_list:
+        msg = (_("Failed to register storage. Reason: same serial number: "
+                 "%s detected.") % storage['serial_number'])
+        LOG.error(msg)
+        raise exception.InvalidRequest(msg)
+
+
+def check_storage_with_access_info(context, storage_id, storage_new):
+    if not storage_new:
+        msg = _("Storage could not be found.")
+        raise exception.StorageNotFound(message=msg)
+
+    if not storage_new.get('serial_number'):
+        msg = _("Serial number should be provided by storage.")
+        raise exception.InvalidResults(message=msg)
+
+    storage_present = db.storage_get(context, storage_id)
+    if storage_new['serial_number'] != storage_present.serial_number:
+        msg = (_("Existing storage serial number is not matching"
+                 " with the new storage serial number: '%s'  ") %
+               storage_new['serial_number'])
+        raise exception.StorageSerialNumberMismatch(message=msg)

--- a/dolphin/drivers/helper.py
+++ b/dolphin/drivers/helper.py
@@ -48,7 +48,7 @@ def update_storage(context, storage_id, storage):
     return db.storage_update(context, storage_id, storage)
 
 
-def check_storage_exist(context, storage):
+def check_storage_repetition(context, storage):
     if not storage:
         msg = _("Storage could not be found.")
         raise exception.StorageNotFound(message=msg)
@@ -66,7 +66,17 @@ def check_storage_exist(context, storage):
         raise exception.InvalidRequest(msg)
 
 
-def check_storage_with_access_info(context, storage_id, storage_new):
+def check_storage_consistency(context, storage_id, storage_new):
+    """Check storage response returned by driver whether it matches the
+    storage stored in database.
+
+    :param context: The context of dolphin.
+    :type context: dolphin.context.RequestContext
+    :param storage_id: The uuid of storage in database.
+    :type storage_id: string
+    :param storage_new: The storage response returned by driver.
+    :type storage_new: dict
+    """
     if not storage_new:
         msg = _("Storage could not be found.")
         raise exception.StorageNotFound(message=msg)
@@ -76,8 +86,8 @@ def check_storage_with_access_info(context, storage_id, storage_new):
         raise exception.InvalidResults(message=msg)
 
     storage_present = db.storage_get(context, storage_id)
-    if storage_new['serial_number'] != storage_present.serial_number:
-        msg = (_("Existing storage serial number is not matching"
-                 " with the new storage serial number: '%s'  ") %
-               storage_new['serial_number'])
+    if storage_new['serial_number'] != storage_present['serial_number']:
+        msg = (_("New storage serial number is not matching "
+                 "with the existing storage serial number: %s") %
+               storage_present['serial_number'])
         raise exception.StorageSerialNumberMismatch(message=msg)

--- a/dolphin/drivers/manager.py
+++ b/dolphin/drivers/manager.py
@@ -51,7 +51,7 @@ class DriverManager(stevedore.ExtensionManager):
         :param cache_on_load: Boolean to decide whether save driver object
             in driver_factory when generating a new driver object.
             It takes effect when invoke_on_load is True.
-        :type invoke_on_load: bool
+        :type cache_on_load: bool
         :param kwargs: Parameters from access_info.
         """
         if not invoke_on_load:
@@ -96,7 +96,7 @@ class DriverManager(stevedore.ExtensionManager):
         name = '%s %s' % (kwargs.get('vendor'), kwargs.get('model'))
         if name in self.names():
             return self[name].plugin
-        else:
-            msg = (_("Storage driver '%s' could not be found.") % name)
-            LOG.error(msg)
-            raise exception.StorageDriverNotFound(message=msg)
+
+        msg = (_("Storage driver '%s' could not be found.") % name)
+        LOG.error(msg)
+        raise exception.StorageDriverNotFound(message=msg)

--- a/dolphin/exception.py
+++ b/dolphin/exception.py
@@ -258,11 +258,13 @@ class PoolNotFound(NotFound):
 class StorageDriverNotFound(NotFound):
     message = _("Storage driver could not be found.")
 
+
 class StorageBackendException(DolphinException):
     message = _("Exception from Storage Backend: %(reason)s.")
 
-class StorageSerialNumberMismatch(DolphinException):
-    message = _("Storage  serial number  mismatch: "
+
+class StorageSerialNumberMismatch(Invalid):
+    message = _("Storage serial number mismatch: "
                 "%(reason)s")
 
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Suppose storage was not saved successfully after access information was saved in database when registering storage. Therefore, we need to check access_info and storage at the same time when user register the storage again. This PR will solve this problem.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
