### PR TITLE
 Resolving merge issue storage update function in DB

### DIFF
--- a/dolphin/db/sqlalchemy/api.py
+++ b/dolphin/db/sqlalchemy/api.py
@@ -246,8 +246,9 @@ def storage_update(context, storage_id, values):
     """Update a storage device with the values dictionary."""
     session = get_session()
     with session.begin():
-        result = _access_info_get(context, storage_id, session).update(values)
-        return result
+        query = _storage_get_query(context, session)
+        result = query.filter_by(id=storage_id).update(values)
+    return result
 
 
 def storage_get(context, storage_id):


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
While merging Access-info update PR, storage_update fucntion was worngly update.
reverting that change.

**Which issue this PR fixes** 
NA
**Special notes for your reviewer**:
**Tesitng Notes**:
1. Registered new storage(fake_storage)
2. Updated fake storage capacity values
3. Updated storage wih new access_info ,
4. verfied that storage is updated with new access_info and capacity values.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
