### PR TITLE
Add db level api to get alert source by filter

### DIFF
--- a/dolphin/db/api.py
+++ b/dolphin/db/api.py
@@ -302,3 +302,27 @@ def alert_source_get(context, storage_id):
 def alert_source_delete(context, storage_id):
     """Delete an alert source."""
     return IMPL.alert_source_delete(context, storage_id)
+
+
+def alert_source_get_all(context, marker=None, limit=None, sort_keys=None,
+                         sort_dirs=None, filters=None, offset=None):
+    """Retrieves all alert sources.
+
+    If no sort parameters are specified then the returned alert sources are
+    sorted first by the 'created_at' key in descending order.
+
+    :param context: context of this request, it's helpful to trace the request
+    :param marker: the last item of the previous page, used to determine the
+                   next page of results to return
+    :param limit: maximum number of items to return
+    :param sort_keys: list of attributes by which results should be sorted,
+                      paired with corresponding item in sort_dirs
+    :param sort_dirs: list of directions in which results should be sorted,
+                      paired with corresponding item in sort_keys, for example
+                      'desc' for descending order
+    :param filters: dictionary of filters
+    :param offset: number of items to skip
+    :returns: list of storage accesses
+    """
+    return IMPL.alert_source_get_all(context, marker, limit, sort_keys,
+                                     sort_dirs, filters, offset)

--- a/dolphin/db/sqlalchemy/api.py
+++ b/dolphin/db/sqlalchemy/api.py
@@ -501,6 +501,17 @@ def _alert_source_get_query(context, session=None):
     return model_query(context, models.AlertSource, session=session)
 
 
+@apply_like_filters(model=models.AlertSource)
+def _process_alert_source_filters(query, filters):
+    """Common filter processing for alert source queries."""
+    if filters:
+        if not is_valid_model_filters(models.AlertSource, filters):
+            return
+        query = query.filter_by(**filters)
+
+    return query
+
+
 def alert_source_create(context, values):
     """Add an alert source configuration."""
     alert_source_ref = models.AlertSource()
@@ -535,12 +546,27 @@ def alert_source_delete(context, storage_id):
             LOG.info("Delete alert source[storage_id=%s] successfully.", storage_id)
 
 
+def alert_source_get_all(context, marker=None, limit=None, sort_keys=None,
+                    sort_dirs=None, filters=None, offset=None):
+    session = get_session()
+    with session.begin():
+        query = _generate_paginate_query(context, session, models.AlertSource,
+                                         marker, limit, sort_keys, sort_dirs,
+                                         filters, offset,
+                                         )
+        if query is None:
+            return []
+        return query.all()
+
+
 PAGINATION_HELPERS = {
     models.AccessInfo: (_access_info_get_query, _process_access_info_filters,
                         _access_info_get),
     models.Pool: (_pool_get_query, _process_pool_info_filters, _pool_get),
     models.Storage: (_storage_get_query, _process_storage_info_filters,
                      _storage_get),
+    models.AlertSource: (_alert_source_get_query, _process_alert_source_filters,
+                         _alert_source_get)
 }
 
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Privode the db level api to get alert source by filter, which will be used by trap_receiver to get alert source by host.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Test report as below.
1. 2 storages:
![image_recompress](https://user-images.githubusercontent.com/38932432/82536451-11caaf80-9b7b-11ea-8884-c1d4b335ac40.jpg)

2. Alert source for each storage:
![image_2__recompress](https://user-images.githubusercontent.com/38932432/82536484-1f803500-9b7b-11ea-9d1e-ccf06945813f.jpg)
![image_2__recompress (1)](https://user-images.githubusercontent.com/38932432/82536500-23ac5280-9b7b-11ea-96ec-d90279a66e77.jpg)

3. Successful trap processing from source 127.0.0.1:
![image_3__recompress](https://user-images.githubusercontent.com/38932432/82536562-3a52a980-9b7b-11ea-8891-bbda4b172931.jpg)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
